### PR TITLE
Initialize Next.js skeleton

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,0 +1,12 @@
+import './globals.css';
+import type { ReactNode } from 'react';
+
+export default function RootLayout({ children }: { children: ReactNode }) {
+  return (
+    <html lang="en">
+      <body className="min-h-screen bg-gray-100 text-gray-900">
+        {children}
+      </body>
+    </html>
+  );
+}

--- a/app/new/page.tsx
+++ b/app/new/page.tsx
@@ -1,0 +1,52 @@
+'use client';
+import { useState } from 'react';
+import GameSelector from '@/components/GameSelector';
+import ModeToggle from '@/components/ModeToggle';
+import PlayerList from '@/components/PlayerList';
+import Link from 'next/link';
+import { useRouter } from 'next/navigation';
+import { useRunStore } from '@/lib/store';
+import type { Run } from '@/lib/models';
+import { nanoid } from 'nanoid';
+
+export default function NewRun() {
+  const router = useRouter();
+  const addRun = useRunStore((s) => s.addRun);
+  const [game, setGame] = useState('FR');
+  const [mode, setMode] = useState<'standard' | 'randomized'>('standard');
+
+  function createRun() {
+    const run: Run = {
+      id: nanoid(),
+      game,
+      mode,
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+      players: [],
+      rules: {
+        dupesClause: true,
+        speciesClause: true,
+        shinyClause: false,
+        setMode: false,
+        levelCapEnforced: false,
+      },
+      encounters: [],
+      badges: [],
+    };
+    addRun(run);
+    router.push(`/run/${run.id}`);
+  }
+
+  return (
+    <main className="p-8 space-y-6">
+      <h1 className="text-xl font-bold">Create New Run</h1>
+      <GameSelector value={game} onChange={setGame} />
+      <ModeToggle value={mode} onChange={setMode} />
+      <PlayerList />
+      <button onClick={createRun} className="px-4 py-2 bg-blue-600 text-white rounded">
+        Create Run
+      </button>
+      <Link href="/" className="text-blue-600 underline block mt-4">Back</Link>
+    </main>
+  );
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,0 +1,12 @@
+import Link from 'next/link';
+
+export default function Home() {
+  return (
+    <main className="p-8">
+      <h1 className="text-2xl font-bold mb-4">Pokémon Nuzlocke Tracker</h1>
+      <Link href="/new" className="px-4 py-2 bg-blue-600 text-white rounded">
+        New Run
+      </Link>
+    </main>
+  );
+}

--- a/app/run/[id]/page.tsx
+++ b/app/run/[id]/page.tsx
@@ -1,0 +1,25 @@
+'use client';
+import { useParams } from 'next/navigation';
+import MapCanvas from '@/components/MapCanvas';
+import EncounterDrawer from '@/components/EncounterDrawer';
+import RuleBar from '@/components/RuleBar';
+import { useRunStore } from '@/lib/store';
+
+export default function RunPage() {
+  const params = useParams();
+  const { id } = params as { id: string };
+  const run = useRunStore((s) => s.runs.find((r) => r.id === id));
+
+  if (!run) return <p className="p-4">Run not found.</p>;
+
+  return (
+    <main className="p-4">
+      <h1 className="text-xl font-bold mb-2">Run {run.id}</h1>
+      <RuleBar />
+      <div className="mt-4 flex">
+        <MapCanvas />
+        <EncounterDrawer />
+      </div>
+    </main>
+  );
+}

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,0 +1,6 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+/// <reference types="next/navigation-types/compat/navigation" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/messages/typescript-error-require-id for more information.

--- a/next.config.js
+++ b/next.config.js
@@ -1,0 +1,8 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  experimental: {
+    appDir: true
+  }
+};
+
+module.exports = nextConfig;

--- a/package.json
+++ b/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "nuzlocke-tracker",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint"
+  },
+  "dependencies": {
+    "next": "14.2.3",
+    "react": "18.2.0",
+    "react-dom": "18.2.0",
+    "zustand": "4.4.1",
+    "nanoid": "5.0.2"
+  },
+  "devDependencies": {
+    "typescript": "5.4.5",
+    "@types/react": "18.2.41",
+    "@types/node": "20.11.30",
+    "tailwindcss": "3.4.3",
+    "autoprefixer": "10.4.17",
+    "postcss": "8.4.33"
+  }
+}

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/src/components/EncounterDrawer.tsx
+++ b/src/components/EncounterDrawer.tsx
@@ -1,0 +1,8 @@
+export default function EncounterDrawer() {
+  return (
+    <aside className="w-64 border-l p-4">
+      <h2 className="font-medium mb-2">Encounter</h2>
+      <p className="text-sm text-gray-600">Select an area on the map to log an encounter.</p>
+    </aside>
+  );
+}

--- a/src/components/GameSelector.tsx
+++ b/src/components/GameSelector.tsx
@@ -1,0 +1,21 @@
+interface Props {
+  value: string;
+  onChange: (game: string) => void;
+}
+
+export default function GameSelector({ value, onChange }: Props) {
+  return (
+    <div>
+      <label className="block mb-2 font-medium">Select Game</label>
+      <select
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        className="border p-2 rounded w-full"
+      >
+        <option value="FR">Fire Red</option>
+        <option value="HGSS">HeartGold / SoulSilver</option>
+        <option value="SV">Scarlet / Violet</option>
+      </select>
+    </div>
+  );
+}

--- a/src/components/MapCanvas.tsx
+++ b/src/components/MapCanvas.tsx
@@ -1,0 +1,12 @@
+export default function MapCanvas() {
+  return (
+    <div className="border p-4 flex-1">
+      <svg viewBox="0 0 100 100" className="w-full h-64 bg-white">
+        <rect x="10" y="10" width="30" height="30" fill="#fde68a" />
+        <rect x="60" y="20" width="30" height="30" fill="#a7f3d0" />
+        <text x="25" y="55" fontSize="8">Area 1</text>
+        <text x="75" y="65" fontSize="8">Area 2</text>
+      </svg>
+    </div>
+  );
+}

--- a/src/components/ModeToggle.tsx
+++ b/src/components/ModeToggle.tsx
@@ -1,0 +1,32 @@
+'use client';
+import { useState } from 'react';
+
+interface Props {
+  value: 'standard' | 'randomized';
+  onChange: (mode: 'standard' | 'randomized') => void;
+}
+
+export default function ModeToggle({ value, onChange }: Props) {
+  const [mode, setMode] = useState<'standard' | 'randomized'>(value);
+  function select(m: 'standard' | 'randomized') {
+    setMode(m);
+    onChange(m);
+  }
+  return (
+    <div className="flex items-center space-x-2">
+      <span>Mode:</span>
+      <button
+        onClick={() => select('standard')}
+        className={`px-2 py-1 rounded ${mode === 'standard' ? 'bg-blue-600 text-white' : 'bg-gray-200'}`}
+      >
+        Standard
+      </button>
+      <button
+        onClick={() => select('randomized')}
+        className={`px-2 py-1 rounded ${mode === 'randomized' ? 'bg-blue-600 text-white' : 'bg-gray-200'}`}
+      >
+        Randomized
+      </button>
+    </div>
+  );
+}

--- a/src/components/PlayerList.tsx
+++ b/src/components/PlayerList.tsx
@@ -1,0 +1,26 @@
+'use client';
+import { useState } from 'react';
+
+export default function PlayerList() {
+  const [players, setPlayers] = useState<string[]>(['Player 1']);
+
+  function addPlayer() {
+    setPlayers((p) => [...p, `Player ${p.length + 1}`]);
+  }
+
+  return (
+    <div>
+      <h2 className="font-medium mb-2">Players</h2>
+      <ul className="mb-2 space-y-1">
+        {players.map((p, i) => (
+          <li key={i} className="p-2 bg-gray-200 rounded">
+            {p}
+          </li>
+        ))}
+      </ul>
+      <button onClick={addPlayer} className="px-2 py-1 bg-green-600 text-white rounded">
+        Add Player
+      </button>
+    </div>
+  );
+}

--- a/src/components/RuleBar.tsx
+++ b/src/components/RuleBar.tsx
@@ -1,0 +1,9 @@
+export default function RuleBar() {
+  return (
+    <div className="p-2 bg-gray-200 flex space-x-2">
+      <span className="px-2 py-1 bg-white rounded">Dupes Clause</span>
+      <span className="px-2 py-1 bg-white rounded">Species Clause</span>
+      <span className="px-2 py-1 bg-white rounded">Level Cap: 20</span>
+    </div>
+  );
+}

--- a/src/lib/models.ts
+++ b/src/lib/models.ts
@@ -1,0 +1,46 @@
+export type Run = {
+  id: string;
+  game: string;
+  mode: 'standard' | 'randomized';
+  createdAt: string;
+  updatedAt: string;
+  players: Player[];
+  rules: RunRules;
+  encounters: Encounter[];
+  badges: Badge[];
+};
+
+export type Player = {
+  id: string;
+  name: string;
+  color: string;
+  avatarUrl?: string;
+};
+
+export type Encounter = {
+  id: string;
+  areaId: string;
+  playerId: string;
+  pokemonId: number;
+  nickname?: string;
+  status: 'alive' | 'dead' | 'boxed' | 'released';
+  level: number;
+  method: string;
+  linkedEncounterIds: string[];
+  isValid: boolean;
+};
+
+export type RunRules = {
+  dupesClause: boolean;
+  speciesClause: boolean;
+  shinyClause: boolean;
+  setMode: boolean;
+  levelCapEnforced: boolean;
+};
+
+export type Badge = {
+  id: string;
+  name: string;
+  obtainedAt?: string;
+  levelCap: number;
+};

--- a/src/lib/store.ts
+++ b/src/lib/store.ts
@@ -1,0 +1,12 @@
+import { create } from 'zustand';
+import type { Run } from './models';
+
+interface RunState {
+  runs: Run[];
+  addRun: (run: Run) => void;
+}
+
+export const useRunStore = create<RunState>((set) => ({
+  runs: [],
+  addRun: (run) => set((state) => ({ runs: [...state.runs, run] })),
+}));

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,11 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  content: [
+    './app/**/*.{js,ts,jsx,tsx}',
+    './components/**/*.{js,ts,jsx,tsx}',
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,25 @@
+{
+  "compilerOptions": {
+    "target": "esnext",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "types": ["node"],
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./src/*"]
+    }
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- set up a Next.js 14 project with TailwindCSS and TypeScript
- implement basic components (GameSelector, ModeToggle, PlayerList, MapCanvas, RuleBar, EncounterDrawer)
- add simple Zustand store and data models
- create pages for home, new run, and run dashboard

## Testing
- `npm install` *(fails: network access required)*

------
https://chatgpt.com/codex/tasks/task_b_683c924edeb48330b84b4079195da666