### PR TITLE
Add setup and test scaffolding

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,10 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "setup": "./setup.sh"
   },
   "dependencies": {
     "next": "14.2.3",
@@ -21,6 +24,10 @@
     "@types/node": "20.11.30",
     "tailwindcss": "3.4.3",
     "autoprefixer": "10.4.17",
-    "postcss": "8.4.33"
+    "postcss": "8.4.33",
+    "vitest": "1.5.0",
+    "@testing-library/react": "14.2.1",
+    "@testing-library/jest-dom": "6.4.2",
+    "jsdom": "24.0.0"
   }
 }

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Install project dependencies
+npm install

--- a/tests/sanity.test.ts
+++ b/tests/sanity.test.ts
@@ -1,0 +1,7 @@
+import { describe, it, expect } from 'vitest';
+
+describe('sanity check', () => {
+  it('true is true', () => {
+    expect(true).toBe(true);
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'jsdom',
+    globals: true,
+  },
+});


### PR DESCRIPTION
## Summary
- add basic `setup.sh` script to install dependencies
- configure Vitest for unit tests
- add a minimal sanity test
- add test and setup npm scripts

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_b_683c95cb43b48330a7b06e0ee4da1492