### PR TITLE
Add StatusBadge component and fix Tailwind path

### DIFF
--- a/src/components/StatusBadge.tsx
+++ b/src/components/StatusBadge.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+
+export type Status = 'alive' | 'dead' | 'boxed' | 'released';
+
+interface Props {
+  status: Status;
+}
+
+const colorMap: Record<Status, string> = {
+  alive: 'bg-green-500 text-white',
+  dead: 'bg-red-600 text-white',
+  boxed: 'bg-yellow-400 text-black',
+  released: 'bg-gray-400 text-white',
+};
+
+export default function StatusBadge({ status }: Props) {
+  return (
+    <span className={`px-2 py-1 rounded text-sm font-medium ${colorMap[status]}`}>
+      {status}
+    </span>
+  );
+}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -2,7 +2,7 @@
 module.exports = {
   content: [
     './app/**/*.{js,ts,jsx,tsx}',
-    './components/**/*.{js,ts,jsx,tsx}',
+    './src/**/*.{js,ts,jsx,tsx}',
   ],
   theme: {
     extend: {},

--- a/tests/StatusBadge.test.tsx
+++ b/tests/StatusBadge.test.tsx
@@ -1,0 +1,15 @@
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import StatusBadge, { Status } from '@/components/StatusBadge';
+
+describe('StatusBadge', () => {
+  const statuses: Status[] = ['alive', 'dead', 'boxed', 'released'];
+
+  it('renders a badge for each status', () => {
+    statuses.forEach((s) => {
+      render(<StatusBadge status={s} />);
+      const badge = screen.getByText(s);
+      expect(badge).toBeInTheDocument();
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add StatusBadge React component to display Pokemon status
- include the component in test suite
- update Tailwind content paths to include `src`

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_b_683c985e283c8330ba9782f214c287ac