### PR TITLE
Add interactive map with pan and area selection

### DIFF
--- a/app/run/[id]/page.tsx
+++ b/app/run/[id]/page.tsx
@@ -1,5 +1,6 @@
 'use client';
 import { useParams } from 'next/navigation';
+import { useState } from 'react';
 import MapCanvas from '@/components/MapCanvas';
 import EncounterDrawer from '@/components/EncounterDrawer';
 import RuleBar from '@/components/RuleBar';
@@ -9,6 +10,7 @@ export default function RunPage() {
   const params = useParams();
   const { id } = params as { id: string };
   const run = useRunStore((s) => s.runs.find((r) => r.id === id));
+  const [selectedArea, setSelectedArea] = useState<string | null>(null);
 
   if (!run) return <p className="p-4">Run not found.</p>;
 
@@ -17,8 +19,8 @@ export default function RunPage() {
       <h1 className="text-xl font-bold mb-2">Run {run.id}</h1>
       <RuleBar />
       <div className="mt-4 flex">
-        <MapCanvas />
-        <EncounterDrawer />
+        <MapCanvas game={run.game} onSelectArea={setSelectedArea} />
+        <EncounterDrawer areaId={selectedArea} />
       </div>
     </main>
   );

--- a/public/maps/FR.svg
+++ b/public/maps/FR.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <rect id="area-1" x="10" y="10" width="30" height="30" fill="#fde68a" />
+  <rect id="area-2" x="60" y="20" width="30" height="30" fill="#a7f3d0" />
+  <text x="25" y="55" font-size="8">Area 1</text>
+  <text x="75" y="65" font-size="8">Area 2</text>
+</svg>

--- a/src/components/EncounterDrawer.tsx
+++ b/src/components/EncounterDrawer.tsx
@@ -1,8 +1,16 @@
-export default function EncounterDrawer() {
+interface Props {
+  areaId?: string | null;
+}
+
+export default function EncounterDrawer({ areaId }: Props) {
   return (
     <aside className="w-64 border-l p-4">
       <h2 className="font-medium mb-2">Encounter</h2>
-      <p className="text-sm text-gray-600">Select an area on the map to log an encounter.</p>
+      {areaId ? (
+        <p className="text-sm">Selected Area: {areaId}</p>
+      ) : (
+        <p className="text-sm text-gray-600">Select an area on the map to log an encounter.</p>
+      )}
     </aside>
   );
 }

--- a/src/components/MapCanvas.tsx
+++ b/src/components/MapCanvas.tsx
@@ -1,12 +1,78 @@
-export default function MapCanvas() {
+'use client';
+import { useEffect, useRef, useState } from 'react';
+
+interface Props {
+  game: string;
+  onSelectArea?: (areaId: string) => void;
+}
+
+export default function MapCanvas({ game, onSelectArea }: Props) {
+  const [svgContent, setSvgContent] = useState('');
+  const [viewBox, setViewBox] = useState<[number, number, number, number]>([0, 0, 100, 100]);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const isPanning = useRef(false);
+  const panStart = useRef({ x: 0, y: 0 });
+  const viewBoxStart = useRef<[number, number, number, number]>([0, 0, 100, 100]);
+
+  useEffect(() => {
+    fetch(`/maps/${game}.svg`)
+      .then((res) => res.text())
+      .then((text) => setSvgContent(text))
+      .catch(() => setSvgContent(''));
+  }, [game]);
+
+  function handleWheel(e: React.WheelEvent) {
+    e.preventDefault();
+    const scale = e.deltaY > 0 ? 1.1 : 0.9;
+    const [x, y, w, h] = viewBox;
+    const nw = w * scale;
+    const nh = h * scale;
+    const nx = x + (w - nw) / 2;
+    const ny = y + (h - nh) / 2;
+    setViewBox([nx, ny, nw, nh]);
+  }
+
+  function handleMouseDown(e: React.MouseEvent) {
+    isPanning.current = true;
+    panStart.current = { x: e.clientX, y: e.clientY };
+    viewBoxStart.current = viewBox;
+  }
+  function handleMouseMove(e: React.MouseEvent) {
+    if (!isPanning.current || !containerRef.current) return;
+    const scaleX = viewBoxStart.current[2] / containerRef.current.clientWidth;
+    const scaleY = viewBoxStart.current[3] / containerRef.current.clientHeight;
+    const dx = (e.clientX - panStart.current.x) * scaleX;
+    const dy = (e.clientY - panStart.current.y) * scaleY;
+    const [x, y, w, h] = viewBoxStart.current;
+    setViewBox([x - dx, y - dy, w, h]);
+  }
+  function endPan() {
+    isPanning.current = false;
+  }
+
+  function handleClick(e: React.MouseEvent) {
+    const target = e.target as HTMLElement;
+    const id = target.id;
+    if (id && onSelectArea) onSelectArea(id);
+  }
+
   return (
-    <div className="border p-4 flex-1">
-      <svg viewBox="0 0 100 100" className="w-full h-64 bg-white">
-        <rect x="10" y="10" width="30" height="30" fill="#fde68a" />
-        <rect x="60" y="20" width="30" height="30" fill="#a7f3d0" />
-        <text x="25" y="55" fontSize="8">Area 1</text>
-        <text x="75" y="65" fontSize="8">Area 2</text>
-      </svg>
+    <div
+      ref={containerRef}
+      className="border p-4 flex-1 bg-white overflow-hidden cursor-pointer"
+      onWheel={handleWheel}
+      onMouseDown={handleMouseDown}
+      onMouseMove={handleMouseMove}
+      onMouseUp={endPan}
+      onMouseLeave={endPan}
+      onClick={handleClick}
+    >
+      <svg
+        viewBox={viewBox.join(' ')}
+        className="w-full h-64 select-none"
+        dangerouslySetInnerHTML={{ __html: svgContent }}
+      />
     </div>
   );
 }
+


### PR DESCRIPTION
## Summary
- make the map interactive with pan and zoom
- load map SVGs from `/public/maps`
- show selected area in the encounter drawer

## Testing
- `npm test` *(fails: `vitest` not found)*

------
https://chatgpt.com/codex/tasks/task_b_683c9a753e408330bc36f53464fad759